### PR TITLE
Remove mentions of "OtterCraft", etc.

### DIFF
--- a/policy.html
+++ b/policy.html
@@ -83,14 +83,13 @@
 <p>Our website uses cookies in order to allow you to use it. Without cookies, the website wouldn't be able to function as we require them in order to keep you logged into your account. You can read more about cookies here: <a href="http://www.whatarecookies.com/">http://www.whatarecookies.com/</a>.
 </p>
 <b>Website usage</b>
-<p>By using our website "ottercraft.net", you agree to follow all rules explained on the rules forum post. Please note that you must be at least 13 years of age to register for an account. OtterCraft follows all US laws, therefore we will remove any content which violates US laws.
+<p>By using our website "yoursite.net", you agree to follow all rules explained on the rules forum post. Please note that you must be at least 13 years of age to register for an account. "Your Site" follows all US laws, therefore we will remove any content which violates US laws.
 </p>
 <b>Data Breaches</b>
 <p>In the case of a data breach, e.g. user database leaked, which may include email addresses and passwords, you will be notified via email about this. All passwords will be reset, with an email sent to you with instructions on how to recover your account. Please keep in mind we take security seriously.
 </p>
 Contact Us
-If you wish to contact us for further information, you can either make a post on the forums, or send an email to "youremail@server.com".
-<p>We will usually get back to you within 24 hours.
+If you wish to contact us for further information, you can either make a post on the forums, or send an email to "youremail@yoursite.net".
 </p>
             </div>
         </div>


### PR DESCRIPTION
So this is a quick little fix. When I was checking out [the demo site](https://www.sidengel.com/dev/materialcraft/policy.html), I found various links to the server "OtterCraft", and a few spelling issues. I've fixed and removed them all, this is all I've done. 😅 